### PR TITLE
mc_cursor finishes returning before stopping

### DIFF
--- a/src/connection/mc_cursor.erl
+++ b/src/connection/mc_cursor.erl
@@ -135,22 +135,22 @@ init([Owner, Connection, Collection, Cursor, BatchSize, Batch,DB]) ->
 %% @hidden
 handle_call({next, Timeout}, _From, State) ->
   case next_i(State, Timeout) of
-    {Reply, #state{cursor = 0, batch = []} = UpdatedState} ->
-      {stop, normal, Reply, UpdatedState};
+    {{}, UpdatedState} ->
+      {stop, normal, {}, UpdatedState};
     {Reply, UpdatedState} ->
       {reply, Reply, UpdatedState}
   end;
 handle_call({rest, Limit, Timeout}, _From, State) ->
   case rest_i(State, Limit, Timeout) of
-    {Reply, #state{cursor = 0} = UpdatedState} ->
-      {stop, normal, Reply, UpdatedState};
+    {{}, UpdatedState} ->
+      {stop, normal, {}, UpdatedState};
     {Reply, UpdatedState} ->
       {reply, Reply, UpdatedState}
   end;
 handle_call({next_batch, Timeout}, _From, State = #state{batchsize = Limit}) ->
   case rest_i(State, Limit, Timeout) of
-    {Reply, #state{cursor = 0} = UpdatedState} ->
-      {stop, normal, Reply, UpdatedState};
+    {{}, UpdatedState} ->
+      {stop, normal, {}, UpdatedState};
     {Reply, UpdatedState} ->
       {reply, Reply, UpdatedState}
   end.


### PR DESCRIPTION
Prior to this, `mc_cursor` processes would shut down after returning the last result, rather than after
returning a final 'empty' to callers. This caused callers to try to call back for 'next()' again when
cursor was already down or going down. That call is a `gen_server:call()`. In the best case, the process
would already be down, and the call would result in a `noproc` exit, which this code catches and
translates into a return value of 'error', instead of the correct `{}` value. In rare cases, though,
due to `gen_server` code, the call would occur at the moment the process terminates, and you'll get
an `exit(normal)` on the calling process instead.